### PR TITLE
refactored findTemplates to fix multi-module build

### DIFF
--- a/src/main/groovy/us/hexcoder/gradle/twirl/task/AbstractCompileTask.groovy
+++ b/src/main/groovy/us/hexcoder/gradle/twirl/task/AbstractCompileTask.groovy
@@ -40,15 +40,7 @@ abstract class AbstractCompileTask extends DefaultTask {
 	}
 
 	def findTemplates(String sourceDirectory) {
-		DirectoryScanner scanner = new DirectoryScanner()
-
-		scanner.setBasedir(getProject().projectDir)
-		scanner.setIncludes(sourceDirectory + "/**/*.scala.*")
-		// TODO: Set excluded files - scanner.setExcludes()
-		scanner.addDefaultExcludes()
-		scanner.scan()
-
-		return Arrays.asList(scanner.getIncludedFiles())
+        	return new FileNameFinder().getFileNames(sourceDirectory, '**/*.scala.*')
 	}
 
 	private static String extensionOf(File file) {


### PR DESCRIPTION
Refactored findTemplates. Original version was not picking up template files when run as part of a multi-module build. Using the in-built groovy FileNameFinder fixed the problem.
