### PR TITLE
Build project with JDK 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,13 @@ group = "us.hexcoder"
 archivesBaseName = "gradle-twirl"
 version = "1.1.0"
 
+project.sourceCompatibility = '1.6'
+project.targetCompatibility = '1.6'
+
 idea {
 	project {
-		jdkName = '1.8'
-		languageLevel = '1.8'
+		jdkName = '1.6'
+		languageLevel = '1.6'
 	}
 
 	module {


### PR DESCRIPTION
This changes will resolve #4, because you dont need to install lesser JDK on system to compile for that JDK. Any JDK itself can compile to lesser JDK version, if compabilty of source code if supported.
